### PR TITLE
Added Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "templavoila",
+  "homepage": "https://forge.typo3.org/projects/extension-templavoila/",
+  "description": "One of many availabe template engines for TYPO3 CMS",
+  "keywords": [
+    "TYPO3",
+    "CMS",
+    "extension",
+    "templating",
+    "TemplaVoila"
+  ],
+  "authors": [
+    "TemplaVoila Team"
+  ],
+  "license": "GPL-2.0+"
+}


### PR DESCRIPTION
<img src="http://yeoman.io/assets/img/yeoman-02.901d.png" align="right"/>

I'm currently working on a [custom Yeoman generator](https://github.com/tollwerk/generator-tollwerk) that will make it a breeze to scaffold a TYPO3 project the way we usually do it at [tollwerk](http://tollwerk.de). The generator will be able to pre-install TYPO3 extensions. I would love to let the generator install TemplaVoila as well, as this is the templating engine we are working with for more than 10 years now and will probably keep on for a while.

For this to work, the repository would need to include an appropriate `bower.json` configuration (I did this as well with [some of my own extensions](https://github.com/jkphl/TYPO3-ext-squeezr) and it works like a charm). Once the configuration file has been merged into the repo, I'll go and publish the extensions to the Bower registry (it'll be available as "templavoila").

I know that TemplaVoila is not to be developed any further. The addition of `bower.json` is, however, a zero-support measure that could help all those folks who are still implementing TemplaVoila, without any significant effort. Thanks for your support!

Cheers, Joschi
